### PR TITLE
fix: node requirement set to node 18

### DIFF
--- a/sdk/typescript-schema/package.json
+++ b/sdk/typescript-schema/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@mparticle/audience-typescript-schema",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "TypeScript schema definitions for mParticle Audiences",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=20.8.1"
+    "node": ">=18.20.4"
   },
   "scripts": {
     "prebuild": "node -e \"require('fs').writeFileSync('version.ts', 'export const VERSION = \\'' + require('./package.json').version + '\\';')\"",

--- a/sdk/typescript-schema/version.ts
+++ b/sdk/typescript-schema/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = '1.0.0'; 
+export const VERSION = '1.0.1';


### PR DESCRIPTION
 ## Summary
- sets node version in package.json to v18
- note: node 20 will still be required for building which is set by .nvmrc
- version bumped

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - {explain how this has been tested, and what, if any, additional testing should be done}

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/REPLACEME
