### PR TITLE
chore: Updating the version declaration when creating the package

### DIFF
--- a/sdk/typescript-schema/scripts/prepare-dist.sh
+++ b/sdk/typescript-schema/scripts/prepare-dist.sh
@@ -12,6 +12,6 @@ if [ -d "dist" ]; then
     VERSION=$(node -p "require('./package.json').version")
     echo "export const VERSION = '$VERSION';" > version.ts
 
-    # Compile version.ts to JavaScript and move to dist directory
-    npx tsc version.ts --outDir dist --module amd --outFile dist/index.js --skipLibCheck
+    # Compile version.ts to JavaScript and declaration files
+    npx tsc version.ts --outDir dist --module amd --declaration --skipLibCheck
 fi


### PR DESCRIPTION
## Summary
The version was not being exported correctly when building the npm package.  This PR also generates and overwrites the version.d.ts in the dist/ folder when the semantic release build runs.

## Testing Plan
Ran the build steps locally and verified this works.