### PR TITLE
feat: add strict_equals binary operator

### DIFF
--- a/sdk/typescript-schema/common/operator.ts
+++ b/sdk/typescript-schema/common/operator.ts
@@ -20,7 +20,8 @@ export enum UnaryOperator {
  * - "contains": { value1: "string", value2: "substring" }
  */
 export type BinaryOperator =
-	"equals"
+	"strict_equals"
+	| "equals"
 	| "not_equals"
 	| "less_than"
 	| "less_than_equal"


### PR DESCRIPTION
 ## Summary
Currently, all date related columns in our customer's DWs are treated as `timestamp`. We need a way to compare dates and datetimes, such that:
- we can check if a datetime occurs on a day, and vice-versa ("equals")
- we can check if a datetime occurs at a specific day and time ("strict equals") 

 ## Testing Plan
 - [ ] Was this tested locally? If not, explain why.
 - {explain how this has been tested, and what, if any, additional testing should be done}

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/REPLACEME
